### PR TITLE
Make altar recipes not mandate using lower-tier crafting altars

### DIFF
--- a/src/main/java/thelm/packagedastral/config/PackagedAstralConfig.java
+++ b/src/main/java/thelm/packagedastral/config/PackagedAstralConfig.java
@@ -36,7 +36,7 @@ public class PackagedAstralConfig {
 		TileDiscoveryCrafter.requiresNight = config.get(category, "requires_night", TileDiscoveryCrafter.requiresNight, "Should the Luminous Package Crafter require night to start nighttime recipes.").getBoolean();
 		TileDiscoveryCrafter.drawMEEnergy = config.get(category, "draw_me_energy", TileDiscoveryCrafter.drawMEEnergy, "Should the Luminous Package Crafter draw energy from ME systems.").getBoolean();
 		category = "blocks.attunement_crafter";
-		TileAttunementCrafter.enabled = TileDiscoveryCrafter.enabled && config.get(category, "enabled", TileAttunementCrafter.enabled, "Should the Starlight Package Crafting Altar be enabled (requires previous tiers).").setRequiresMcRestart(true).getBoolean();
+		TileAttunementCrafter.enabled = config.get(category, "enabled", TileAttunementCrafter.enabled, "Should the Starlight Package Crafting Altar be enabled.").setRequiresMcRestart(true).getBoolean();
 		TileAttunementCrafter.energyCapacity = config.get(category, "energy_capacity", TileAttunementCrafter.energyCapacity, "How much FE the Starlight Package Crafting Altar should hold.", 0, Integer.MAX_VALUE).getInt();
 		TileAttunementCrafter.energyReq = config.get(category, "energy_req", TileAttunementCrafter.energyReq, "How much FE the Starlight Package Crafting Altar should use.", 0, Integer.MAX_VALUE).getInt();
 		TileAttunementCrafter.energyUsage = config.get(category, "energy_usage", TileAttunementCrafter.energyUsage, "How much FE/t maximum the Starlight Package Crafting Altar should use.", 0, Integer.MAX_VALUE).getInt();
@@ -45,7 +45,7 @@ public class PackagedAstralConfig {
 		TileAttunementCrafter.requiresNight = config.get(category, "requires_night", TileAttunementCrafter.requiresNight, "Should the Starlight Package Crafting Altar require night to start nighttime recipes.").getBoolean();
 		TileAttunementCrafter.drawMEEnergy = config.get(category, "draw_me_energy", TileAttunementCrafter.drawMEEnergy, "Should the Starlight Package Crafting Altar draw energy from ME systems.").getBoolean();
 		category = "blocks.constellation_crafter";
-		TileConstellationCrafter.enabled = TileAttunementCrafter.enabled && config.get(category, "enabled", TileConstellationCrafter.enabled, "Should the Celestial Package Crafting Altar be enabled (requires previous tiers).").setRequiresMcRestart(true).getBoolean();
+		TileConstellationCrafter.enabled = config.get(category, "enabled", TileConstellationCrafter.enabled, "Should the Celestial Package Crafting Altar be enabled.").setRequiresMcRestart(true).getBoolean();
 		TileConstellationCrafter.energyCapacity = config.get(category, "energy_capacity", TileConstellationCrafter.energyCapacity, "How much FE the Celestial Package Crafting Altar should hold.", 0, Integer.MAX_VALUE).getInt();
 		TileConstellationCrafter.energyReq = config.get(category, "energy_req", TileConstellationCrafter.energyReq, "How much FE the Celestial Package Crafting Altar should use.", 0, Integer.MAX_VALUE).getInt();
 		TileConstellationCrafter.energyUsage = config.get(category, "energy_usage", TileConstellationCrafter.energyUsage, "How much FE/t maximum the Celestial Package Crafting Altar should use.", 0, Integer.MAX_VALUE).getInt();
@@ -54,7 +54,7 @@ public class PackagedAstralConfig {
 		TileConstellationCrafter.requiresNight = config.get(category, "requires_night", TileConstellationCrafter.requiresNight, "Should the Celestial Package Crafting Altar require night to start nighttime recipes.").getBoolean();
 		TileConstellationCrafter.drawMEEnergy = config.get(category, "draw_me_energy", TileConstellationCrafter.drawMEEnergy, "Should the Celestial Package Crafting Altar draw energy from ME systems.").getBoolean();
 		category = "blocks.trait_crafter";
-		TileTraitCrafter.enabled = TileConstellationCrafter.enabled && config.get(category, "enabled", TileTraitCrafter.enabled, "Should the Iridescent Package Crafting Altar be enabled (requires previous tiers).").setRequiresMcRestart(true).getBoolean();
+		TileTraitCrafter.enabled = config.get(category, "enabled", TileTraitCrafter.enabled, "Should the Iridescent Package Crafting Altar be enabled.").setRequiresMcRestart(true).getBoolean();
 		TileTraitCrafter.energyCapacity = config.get(category, "energy_capacity", TileTraitCrafter.energyCapacity, "How much FE the Iridescent Package Crafting Altar should hold.", 0, Integer.MAX_VALUE).getInt();
 		TileTraitCrafter.energyReq = config.get(category, "energy_req", TileTraitCrafter.energyReq, "How much FE the Iridescent Package Crafting Altar should use.", 0, Integer.MAX_VALUE).getInt();
 		TileTraitCrafter.energyUsage = config.get(category, "energy_usage", TileTraitCrafter.energyUsage, "How much FE/t maximum the Iridescent Package Crafting Altar should use.", 0, Integer.MAX_VALUE).getInt();

--- a/src/main/java/thelm/packagedastral/recipe/RecipeAttunementCrafter.java
+++ b/src/main/java/thelm/packagedastral/recipe/RecipeAttunementCrafter.java
@@ -7,8 +7,10 @@ import hellfirepvp.astralsorcery.common.crafting.ItemHandle;
 import hellfirepvp.astralsorcery.common.crafting.altar.recipes.AttunementRecipe;
 import hellfirepvp.astralsorcery.common.crafting.helper.ShapedRecipeSlot;
 import hellfirepvp.astralsorcery.common.lib.BlocksAS;
+import net.minecraft.item.ItemStack;
 import thelm.packagedastral.block.BlockAttunementCrafter;
 import thelm.packagedastral.block.BlockDiscoveryCrafter;
+import thelm.packagedastral.tile.TileDiscoveryCrafter;
 
 public class RecipeAttunementCrafter extends AttunementRecipe implements INighttimeRecipe {
 
@@ -16,7 +18,7 @@ public class RecipeAttunementCrafter extends AttunementRecipe implements INightt
 
 	protected RecipeAttunementCrafter() {
 		super(shapedRecipe("packagedastral/attunement_crafter", BlockAttunementCrafter.INSTANCE).
-				addPart(BlockDiscoveryCrafter.INSTANCE, ShapedRecipeSlot.CENTER).
+				addPart(TileDiscoveryCrafter.enabled ? new ItemStack(BlockDiscoveryCrafter.INSTANCE) : new ItemStack(BlocksAS.blockAltar, 1, 1), ShapedRecipeSlot.CENTER).
 				addPart(ItemHandle.getCrystalVariant(false, false), ShapedRecipeSlot.UPPER_CENTER).
 				addPart(BlocksAS.fluidLiquidStarlight, ShapedRecipeSlot.LOWER_CENTER).
 				addPart(BlockMarble.MarbleBlockType.CHISELED.asStack(), ShapedRecipeSlot.LEFT, ShapedRecipeSlot.RIGHT).

--- a/src/main/java/thelm/packagedastral/recipe/RecipeAttunementCrafter.java
+++ b/src/main/java/thelm/packagedastral/recipe/RecipeAttunementCrafter.java
@@ -7,7 +7,6 @@ import hellfirepvp.astralsorcery.common.crafting.ItemHandle;
 import hellfirepvp.astralsorcery.common.crafting.altar.recipes.AttunementRecipe;
 import hellfirepvp.astralsorcery.common.crafting.helper.ShapedRecipeSlot;
 import hellfirepvp.astralsorcery.common.lib.BlocksAS;
-import net.minecraft.item.ItemStack;
 import thelm.packagedastral.block.BlockAttunementCrafter;
 import thelm.packagedastral.block.BlockDiscoveryCrafter;
 import thelm.packagedastral.tile.TileDiscoveryCrafter;
@@ -18,7 +17,7 @@ public class RecipeAttunementCrafter extends AttunementRecipe implements INightt
 
 	protected RecipeAttunementCrafter() {
 		super(shapedRecipe("packagedastral/attunement_crafter", BlockAttunementCrafter.INSTANCE).
-				addPart(TileDiscoveryCrafter.enabled ? new ItemStack(BlockDiscoveryCrafter.INSTANCE) : new ItemStack(BlocksAS.blockAltar, 1, 1), ShapedRecipeSlot.CENTER).
+				addPart(TileDiscoveryCrafter.enabled ? BlockDiscoveryCrafter.INSTANCE : BlocksAS.blockAltar, ShapedRecipeSlot.CENTER).
 				addPart(ItemHandle.getCrystalVariant(false, false), ShapedRecipeSlot.UPPER_CENTER).
 				addPart(BlocksAS.fluidLiquidStarlight, ShapedRecipeSlot.LOWER_CENTER).
 				addPart(BlockMarble.MarbleBlockType.CHISELED.asStack(), ShapedRecipeSlot.LEFT, ShapedRecipeSlot.RIGHT).

--- a/src/main/java/thelm/packagedastral/recipe/RecipeConstellationCrafter.java
+++ b/src/main/java/thelm/packagedastral/recipe/RecipeConstellationCrafter.java
@@ -17,7 +17,6 @@ import hellfirepvp.astralsorcery.common.lib.BlocksAS;
 import hellfirepvp.astralsorcery.common.tile.TileAltar;
 import hellfirepvp.astralsorcery.common.util.MiscUtils;
 import hellfirepvp.astralsorcery.common.util.data.Vector3;
-import net.minecraft.item.ItemStack;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 import thelm.packagedastral.block.BlockAttunementCrafter;
@@ -34,7 +33,7 @@ public class RecipeConstellationCrafter extends ConstellationRecipe implements I
 
 	protected RecipeConstellationCrafter() {
 		super(shapedRecipe("packagedastral/constellation_crafter", BlockConstellationCrafter.INSTANCE).
-				addPart(TileAttunementCrafter.enabled ? new ItemStack(BlockAttunementCrafter.INSTANCE) : new ItemStack(BlocksAS.blockAltar, 1, 2), ShapedRecipeSlot.CENTER).
+				addPart(TileAttunementCrafter.enabled ? BlockAttunementCrafter.INSTANCE : BlocksAS.blockAltar, ShapedRecipeSlot.CENTER).
 				addPart(ItemHandle.getCrystalVariant(false, false), ShapedRecipeSlot.UPPER_CENTER).
 				addPart("ingotAstralStarmetal", ShapedRecipeSlot.LOWER_CENTER).
 				addPart(BlockMarble.MarbleBlockType.CHISELED.asStack(), ShapedRecipeSlot.LEFT, ShapedRecipeSlot.RIGHT).

--- a/src/main/java/thelm/packagedastral/recipe/RecipeConstellationCrafter.java
+++ b/src/main/java/thelm/packagedastral/recipe/RecipeConstellationCrafter.java
@@ -13,13 +13,16 @@ import hellfirepvp.astralsorcery.common.crafting.altar.ActiveCraftingTask;
 import hellfirepvp.astralsorcery.common.crafting.altar.recipes.ConstellationRecipe;
 import hellfirepvp.astralsorcery.common.crafting.helper.ShapedRecipeSlot;
 import hellfirepvp.astralsorcery.common.item.ItemCraftingComponent;
+import hellfirepvp.astralsorcery.common.lib.BlocksAS;
 import hellfirepvp.astralsorcery.common.tile.TileAltar;
 import hellfirepvp.astralsorcery.common.util.MiscUtils;
 import hellfirepvp.astralsorcery.common.util.data.Vector3;
+import net.minecraft.item.ItemStack;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 import thelm.packagedastral.block.BlockAttunementCrafter;
 import thelm.packagedastral.block.BlockConstellationCrafter;
+import thelm.packagedastral.tile.TileAttunementCrafter;
 
 public class RecipeConstellationCrafter extends ConstellationRecipe implements INighttimeRecipe, ISpecialCraftingEffects {
 
@@ -31,7 +34,7 @@ public class RecipeConstellationCrafter extends ConstellationRecipe implements I
 
 	protected RecipeConstellationCrafter() {
 		super(shapedRecipe("packagedastral/constellation_crafter", BlockConstellationCrafter.INSTANCE).
-				addPart(BlockAttunementCrafter.INSTANCE, ShapedRecipeSlot.CENTER).
+				addPart(TileAttunementCrafter.enabled ? new ItemStack(BlockAttunementCrafter.INSTANCE) : new ItemStack(BlocksAS.blockAltar, 1, 2), ShapedRecipeSlot.CENTER).
 				addPart(ItemHandle.getCrystalVariant(false, false), ShapedRecipeSlot.UPPER_CENTER).
 				addPart("ingotAstralStarmetal", ShapedRecipeSlot.LOWER_CENTER).
 				addPart(BlockMarble.MarbleBlockType.CHISELED.asStack(), ShapedRecipeSlot.LEFT, ShapedRecipeSlot.RIGHT).

--- a/src/main/java/thelm/packagedastral/recipe/RecipeTraitCrafter.java
+++ b/src/main/java/thelm/packagedastral/recipe/RecipeTraitCrafter.java
@@ -18,16 +18,19 @@ import hellfirepvp.astralsorcery.common.crafting.altar.recipes.upgrade.TraitUpgr
 import hellfirepvp.astralsorcery.common.crafting.helper.ShapedRecipeSlot;
 import hellfirepvp.astralsorcery.common.item.ItemCraftingComponent;
 import hellfirepvp.astralsorcery.common.item.useables.ItemUsableDust;
+import hellfirepvp.astralsorcery.common.lib.BlocksAS;
 import hellfirepvp.astralsorcery.common.lib.Constellations;
 import hellfirepvp.astralsorcery.common.tile.TileAltar;
 import hellfirepvp.astralsorcery.common.util.MiscUtils;
 import hellfirepvp.astralsorcery.common.util.data.Vector3;
 import net.minecraft.init.Items;
+import net.minecraft.item.ItemStack;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 import thelm.packagedastral.block.BlockConstellationCrafter;
 import thelm.packagedastral.block.BlockTraitCrafter;
 import thelm.packagedastral.item.ItemConstellationFocus;
+import thelm.packagedastral.tile.TileConstellationCrafter;
 
 public class RecipeTraitCrafter extends TraitRecipe implements INighttimeRecipe, ISpecialCraftingEffects {
 
@@ -39,7 +42,7 @@ public class RecipeTraitCrafter extends TraitRecipe implements INighttimeRecipe,
 
 	protected RecipeTraitCrafter() {
 		super(shapedRecipe("packagedastral/trait_crafter", BlockTraitCrafter.INSTANCE).
-				addPart(BlockConstellationCrafter.INSTANCE, ShapedRecipeSlot.CENTER).
+				addPart(TileConstellationCrafter.enabled ? new ItemStack(BlockConstellationCrafter.INSTANCE) : new ItemStack(BlocksAS.blockAltar, 1, 3), ShapedRecipeSlot.CENTER).
 				addPart(ItemConstellationFocus.INSTANCE, ShapedRecipeSlot.UPPER_CENTER).
 				addPart(ItemHandle.getCrystalVariant(false, true), ShapedRecipeSlot.LOWER_CENTER).
 				addPart(Items.ENDER_EYE, ShapedRecipeSlot.LEFT, ShapedRecipeSlot.RIGHT).

--- a/src/main/java/thelm/packagedastral/recipe/RecipeTraitCrafter.java
+++ b/src/main/java/thelm/packagedastral/recipe/RecipeTraitCrafter.java
@@ -24,7 +24,6 @@ import hellfirepvp.astralsorcery.common.tile.TileAltar;
 import hellfirepvp.astralsorcery.common.util.MiscUtils;
 import hellfirepvp.astralsorcery.common.util.data.Vector3;
 import net.minecraft.init.Items;
-import net.minecraft.item.ItemStack;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 import thelm.packagedastral.block.BlockConstellationCrafter;
@@ -42,7 +41,7 @@ public class RecipeTraitCrafter extends TraitRecipe implements INighttimeRecipe,
 
 	protected RecipeTraitCrafter() {
 		super(shapedRecipe("packagedastral/trait_crafter", BlockTraitCrafter.INSTANCE).
-				addPart(TileConstellationCrafter.enabled ? new ItemStack(BlockConstellationCrafter.INSTANCE) : new ItemStack(BlocksAS.blockAltar, 1, 3), ShapedRecipeSlot.CENTER).
+				addPart(TileConstellationCrafter.enabled ? BlockConstellationCrafter.INSTANCE : BlocksAS.blockAltar, ShapedRecipeSlot.CENTER).
 				addPart(ItemConstellationFocus.INSTANCE, ShapedRecipeSlot.UPPER_CENTER).
 				addPart(ItemHandle.getCrystalVariant(false, true), ShapedRecipeSlot.LOWER_CENTER).
 				addPart(Items.ENDER_EYE, ShapedRecipeSlot.LEFT, ShapedRecipeSlot.RIGHT).


### PR DESCRIPTION
changes in this PR:
- allows higher-tier PackagedAstral altars to be enabled even if lower-tier PackagedAstral altars are disabled.
- removes config description note about requiring lower-tier PackagedAstral altars to be enabled.
- makes PackagedAstral altar recipes check if the lower-tier PackagedAstral altar is enabled. if it is enabled, use it, otherwise, use the Astral Sorcery Luminous Crafting Table instead.

resolves #4